### PR TITLE
docs: fill missing coffee roaster locations

### DIFF
--- a/src/data/coffee.ts
+++ b/src/data/coffee.ts
@@ -176,13 +176,13 @@ export const coffeeRoasters = [
     name: "Randall Coffee",
     url: "https://randallcoffee.com/",
     subscription: true,
-    location: "-",
+    location: "Мадрид",
   },
   {
     name: "Religion",
     url: "https://religioncoffeeshop.com/",
     subscription: true,
-    location: "-",
+    location: "Мадрид",
   },
   {
     name: "Right Side coffee",


### PR DESCRIPTION
## Что сделано
- заполнил отсутствующее поле `location` для `Randall Coffee`
- заполнил отсутствующее поле `location` для `Religion`

## Почему
В `src/data/coffee.ts` у двух обжарщиков вместо города стоял `-`, из-за чего список был неполным и менее полезным для читателей.

Локации проверил по сайтам самих компаний:
- `Randall Coffee` — на главной странице явно указан Мадрид (`Café De Especialidad En Madrid`)
- `Religion` — на странице `CONTACTO` указаны несколько адресов в Мадриде (`María de Molina 24`, `Príncipe de Vergara 16`, `Méndez Álvaro 61`)

## Проверка
- посмотрел diff и убедился, что меняются только 2 строки
- отдельно проверил, что сайты `Randall Coffee` и `Religion` открываются и подтверждают локацию

## Примечание
В репозитории есть несвязанные проблемы: `biome:ci` сейчас падает на форматировании `src/data/coffee.test.ts`, а один тест отдельно падает на `Lyv coffee` из-за ответа сайта. Эти проблемы в PR не трогал.