### PR TITLE
fix: migrate content config to Astro v6 Content Layer API

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,10 @@
+import { defineCollection } from "astro:content";
+import { docsSchema } from "@astrojs/starlight/schema";
+import { glob } from "astro/loaders";
+
+export const collections = {
+  docs: defineCollection({
+    loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/docs" }),
+    schema: docsSchema(),
+  }),
+};

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,6 +1,0 @@
-import { defineCollection } from "astro:content";
-import { docsSchema } from "@astrojs/starlight/schema";
-
-export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
-};


### PR DESCRIPTION
## Summary
- Move `src/content/config.ts` → `src/content.config.ts` (required by Astro v6)
- Add `glob` loader for the `docs` collection (legacy content collections removed in v6)

This fixes the `LegacyContentConfigError` CI failure on `astro check && astro build`.

## Context
Astro v6 removes backwards compatibility for legacy content collections. The config file must live at `src/content.config.ts` (not `src/content/config.ts`) and every collection must define a `loader`.

## Test Plan
- [x] CI build passes after merge
- [x] OG image generation still works (uses `getCollection` + `id`, unchanged)

Closes the CI failure in https://github.com/r3nya/madrid101/actions/runs/25179531067
