### PR TITLE
chore: set minimum release age for package updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
Добавлена настройка minimum release age для задержки автообновлений пакетов.

- pnpm-проекты: `minimumReleaseAge=2880` (48 часов)
- npm-проект: `min-release-age=2` (дня)

Это предотвращает немедленное применение свежих релизов Dependabot, давая время на выявление регрессий.