### PR TITLE
chore(deps): add dependabot cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
       time: "09:00"
       day: "monday"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+      include:
+        - "*"
     # Groups for version updates - security updates create individual PRs automatically
     groups:
       # Production dependencies (all except astro-related)
@@ -57,6 +64,11 @@ updates:
       timezone: "Europe/Madrid"
       time: "09:00"
       day: "monday"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 14
+      include:
+        - "*"
     groups:
       github-actions:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2874,21 +2874,6 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
-    "node_modules/astro/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",


### PR DESCRIPTION
## What

Add cooldown configuration to Dependabot matching other pet projects (grok99 pattern).

## Changes

| Ecosystem | default | major | minor | patch |
|-----------|---------|-------|-------|-------|
| npm | 14d | 30d | 14d | 7d |
| github-actions | 14d | — | — | — |

This reduces PR noise by spacing out dependency update batches instead of getting flooded weekly.