### PR TITLE
chore(deps): add commit-message prefix for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       time: "09:00"
       day: "monday"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     cooldown:
       default-days: 14
       semver-major-days: 30
@@ -65,6 +68,8 @@ updates:
       time: "09:00"
       day: "monday"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
     cooldown:
       default-days: 14
       include:


### PR DESCRIPTION
## Summary

Add conventional commit message prefix for Dependabot PRs.

- **npm**:  / 
- **github-actions**: 
