### PR TITLE
chore: add prefer-dedupe to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=2
+prefer-dedupe=true


### PR DESCRIPTION
## Summary

- Add `prefer-dedupe=true` to `.npmrc`

## Why

npm will prefer deduplicating packages during install, reducing duplication in node_modules. Equivalent of pnpm's `dedupePeerDependents: true` for npm projects.